### PR TITLE
removed  'status': 401 field from the JWT authentication error response

### DIFF
--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -22,8 +22,7 @@ def custom_exception_handler(exc, context):
     if isinstance(exc, (InvalidToken, AuthenticationFailed, NotAuthenticated)):
         return Response(
             {
-                "message": "Token is invalid or expired",
-                "status": status.HTTP_401_UNAUTHORIZED
+                "message": "Token is invalid or expired"
             },
             status=status.HTTP_401_UNAUTHORIZED
         )

--- a/app/core/tests/test_exceptions.py
+++ b/app/core/tests/test_exceptions.py
@@ -34,7 +34,6 @@ class CustomExceptionHandlerTests(APITestCase):
 
         # Assert custom response format
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertEqual(response.data['status'], 401)
         self.assertEqual(
             response.data['message'], 'Token is invalid or expired'
         )
@@ -59,7 +58,6 @@ class CustomExceptionHandlerTests(APITestCase):
 
         # Assert custom response format
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertEqual(response.data['status'], 401)
         self.assertEqual(
             response.data['message'], 'Token is invalid or expired'
         )
@@ -71,7 +69,6 @@ class CustomExceptionHandlerTests(APITestCase):
 
         # Assert custom response format
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertEqual(response.data['status'], 401)
         self.assertEqual(
             response.data['message'], 'Token is invalid or expired'
         )


### PR DESCRIPTION
* [removed the redundant 'status': 401 field from the JWT authentication error response](https://github.com/Nikhilcs36/tdd_backend_python_django_project/commit/6e7d6394462ad07e927aa86cbda502f0aec49027)