### PR TITLE
feat: implement relative URL media file responses

### DIFF
--- a/app/user/fields.py
+++ b/app/user/fields.py
@@ -1,0 +1,18 @@
+"""Custom DRF fields for user app."""
+from django.conf import settings
+from rest_framework import serializers
+
+
+class RelativeURLFileField(serializers.FileField):
+    """
+    A FileField that returns relative URLs instead of absolute URLs.
+
+    Returns: /media/uploads/user/image.jpg
+    Instead of: http://backend:8000/media/uploads/user/image.jpg
+    """
+
+    def to_representation(self, value):
+        """Return relative URL for the file."""
+        if not value:
+            return None
+        return f"{settings.MEDIA_URL}{value.name}"

--- a/app/user/serializers.py
+++ b/app/user/serializers.py
@@ -6,6 +6,7 @@ from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.exceptions import TokenError
 from core.models import LoginActivity
+from .fields import RelativeURLFileField
 from .validators import (
     validate_username,
     validate_email_for_signup,
@@ -21,10 +22,9 @@ class UserSerializer(serializers.ModelSerializer):
         style={'input_type': 'password'},
         error_messages={'blank': 'password_repeat_null'}
     )
-    image = serializers.FileField(
+    image = RelativeURLFileField(
         max_length=100,
         allow_empty_file=True,
-        use_url=True,
         required=False,
         allow_null=True
     )

--- a/app/user/tests/test_relative_url_field.py
+++ b/app/user/tests/test_relative_url_field.py
@@ -1,0 +1,66 @@
+"""Tests for RelativeURLFileField."""
+from django.test import TestCase
+from rest_framework import serializers
+from unittest.mock import MagicMock
+
+from user.fields import RelativeURLFileField
+
+
+class TestSerializer(serializers.Serializer):
+    """Test serializer using RelativeURLFileField."""
+    image = RelativeURLFileField(required=False, allow_null=True)
+
+
+class RelativeURLFileFieldTests(TestCase):
+    """Test cases for RelativeURLFileField."""
+
+    def test_returns_relative_url_with_media_url(self):
+        """Test that the field returns a relative URL with MEDIA_URL prefix."""
+        field = RelativeURLFileField()
+        mock_file = MagicMock()
+        mock_file.name = 'uploads/user/test-image.jpg'
+
+        result = field.to_representation(mock_file)
+
+        self.assertEqual(result, '/media/uploads/user/test-image.jpg')
+
+    def test_returns_none_for_null_value(self):
+        """Test that the field returns None when value is None."""
+        field = RelativeURLFileField()
+
+        result = field.to_representation(None)
+
+        self.assertIsNone(result)
+
+    def test_returns_none_for_empty_string(self):
+        """Test that the field returns None when value is empty string."""
+        field = RelativeURLFileField()
+
+        result = field.to_representation('')
+
+        self.assertIsNone(result)
+
+    def test_serializer_outputs_relative_url(self):
+        """Test serializer outputs relative URL in API response."""
+        mock_file = MagicMock()
+        mock_file.name = 'uploads/user/profile.png'
+
+        serializer = TestSerializer({'image': mock_file})
+
+        self.assertEqual(
+            serializer.data['image'],
+            '/media/uploads/user/profile.png'
+        )
+
+    def test_url_does_not_contain_domain(self):
+        """Test that the returned URL does not contain http:// or domain."""
+        field = RelativeURLFileField()
+        mock_file = MagicMock()
+        mock_file.name = 'uploads/user/photo.jpg'
+
+        result = field.to_representation(mock_file)
+
+        self.assertNotIn('http://', result)
+        self.assertNotIn('https://', result)
+        self.assertNotIn('backend:8000', result)
+        self.assertTrue(result.startswith('/media/'))

--- a/app/user/tests/test_user_api.py
+++ b/app/user/tests/test_user_api.py
@@ -755,8 +755,8 @@ class PrivateUserApiTests(TestCase):
         self.user.refresh_from_db()
         self.assertFalse(self.user.image)
 
-    def test_image_url_is_absolute(self):
-        """Test that the image URL in the response is an absolute URL."""
+    def test_image_url_is_relative(self):
+        """Test that the image URL in the response is a relative URL."""
         image_path = os.path.join(
             settings.MEDIA_ROOT, 'uploads', 'user', '29-png.png'
         )
@@ -768,7 +768,9 @@ class PrivateUserApiTests(TestCase):
 
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertIn('image', res.data)
-        self.assertTrue(res.data['image'].startswith('http'))
+        self.assertTrue(res.data['image'].startswith('/media/'))
+        self.assertNotIn('http://', res.data['image'])
+        self.assertNotIn('https://', res.data['image'])
 
     def test_upload_image_too_large_fail(self):
         """Test uploading an image that is too large."""


### PR DESCRIPTION
Replace absolute URLs with relative URLs for user profile images. Before: http://backend:8000/media/uploads/user/image.jpg After:  /media/uploads/user/image.jpg

Changes:
- Create user/fields.py with RelativeURLFileField
- Update UserSerializer.image field
- Update existing tests and add new unit tests