### PR TITLE
feat: add login success/failure breakdown to user dashboard stats

### DIFF
--- a/app/user/serializers_dashboard.py
+++ b/app/user/serializers_dashboard.py
@@ -31,6 +31,8 @@ class UserStatsSerializer(serializers.Serializer):
     weekly_data = serializers.JSONField()
     monthly_data = serializers.JSONField()
     login_trend = serializers.IntegerField()
+    total_successful_logins = serializers.IntegerField()
+    total_failed_logins = serializers.IntegerField()
 
 
 class AdminDashboardSerializer(serializers.Serializer):
@@ -125,43 +127,56 @@ def get_user_stats(user, start_date=None, end_date=None):
         # Compute stats dynamically from LoginActivity records
         activities = LoginActivity.objects.filter(
             user=user,
-            timestamp__range=(start_date, end_date),
-            success=True
+            timestamp__range=(start_date, end_date)
         )
+        successful_activities = activities.filter(success=True)
 
-        # Calculate total logins in date range
-        total_logins = activities.count()
+        # Calculate successful and failed login counts
+        total_successful_logins = successful_activities.count()
+        total_failed_logins = activities.filter(success=False).count()
+
+        # Calculate total logins (all attempts: successful + failed)
+        total_logins = total_successful_logins + total_failed_logins
 
         # Calculate last login in date range
-        last_login_activity = activities.order_by('-timestamp').first()
+        last_login_activity = successful_activities.order_by(
+            '-timestamp'
+        ).first()
         last_login = (
             last_login_activity.timestamp if last_login_activity else None
         )
 
         # Calculate weekly data
         weekly_data = {}
-        for activity in activities:
+        for activity in successful_activities:
             week_key = activity.timestamp.strftime('%Y-%U')
             weekly_data[week_key] = weekly_data.get(week_key, 0) + 1
 
         # Calculate monthly data
         monthly_data = {}
-        for activity in activities:
+        for activity in successful_activities:
             month_key = activity.timestamp.strftime('%Y-%m')
             monthly_data[month_key] = monthly_data.get(month_key, 0) + 1
 
-        # Calculate login trend (simplified - compare first half vs second half of period)  # noqa: E501
-        if activities.exists():
+        # Calculate login trend (simplified - compare first half vs second
+        # half of period)
+        if successful_activities.exists():
             period_days = (end_date - start_date).days
             midpoint = start_date + timedelta(days=period_days // 2)
 
-            first_half = activities.filter(timestamp__lt=midpoint).count()
-            second_half = activities.filter(timestamp__gte=midpoint).count()
+            first_half = successful_activities.filter(
+                timestamp__lt=midpoint
+            ).count()
+            second_half = successful_activities.filter(
+                timestamp__gte=midpoint
+            ).count()
 
             if first_half == 0:
                 login_trend = 100 if second_half > 0 else 0
             else:
-                trend_calc = ((second_half - first_half) / first_half) * 100
+                trend_calc = (
+                    (second_half - first_half) / first_half
+                ) * 100
                 login_trend = int(trend_calc)
         else:
             login_trend = 0
@@ -174,18 +189,33 @@ def get_user_stats(user, start_date=None, end_date=None):
             ),
             'weekly_data': weekly_data,
             'monthly_data': monthly_data,
-            'login_trend': login_trend
+            'login_trend': login_trend,
+            'total_successful_logins': total_successful_logins,
+            'total_failed_logins': total_failed_logins,
         }
     else:
         # Use default behavior - pre-computed stats from User model
         user.refresh_from_db()
 
+        # Calculate successful and failed from LoginActivity records
+        total_successful_logins = LoginActivity.objects.filter(
+            user=user, success=True
+        ).count()
+        total_failed_logins = LoginActivity.objects.filter(
+            user=user, success=False
+        ).count()
+
+        # Calculate total logins (all attempts: successful + failed)
+        total_logins = total_successful_logins + total_failed_logins
+
         return {
-            'total_logins': user.login_count or 0,
+            'total_logins': total_logins,
             'last_login': user.last_login_timestamp.strftime('%Y-%m-%d %H:%M:%S') if user.last_login_timestamp else None,  # noqa: E501
             'weekly_data': user.weekly_logins or {},
             'monthly_data': user.monthly_logins or {},
-            'login_trend': calculate_login_trend(user)
+            'login_trend': calculate_login_trend(user),
+            'total_successful_logins': total_successful_logins,
+            'total_failed_logins': total_failed_logins,
         }
 
 

--- a/app/user/tests/test_dashboard_api.py
+++ b/app/user/tests/test_dashboard_api.py
@@ -168,8 +168,10 @@ class DashboardAPITests(TestCase):
         url = reverse('user:dashboard-stats')
         response = self.client.get(url)
 
-        # Should only count successful logins (5)
-        self.assertEqual(response.data['total_logins'], 5)
+        # Should count all login attempts (5 successful + 2 failed = 7)
+        self.assertEqual(response.data['total_logins'], 7)
+        self.assertEqual(response.data['total_successful_logins'], 5)
+        self.assertEqual(response.data['total_failed_logins'], 2)
 
     def test_user_stats_includes_login_trend_calculation(self):
         """Test that user stats includes login trend calculation."""
@@ -207,7 +209,8 @@ class DashboardAPITests(TestCase):
         # Verify complete response structure
         expected_keys = [
             'total_logins', 'last_login', 'weekly_data',
-            'monthly_data', 'login_trend'
+            'monthly_data', 'login_trend',
+            'total_successful_logins', 'total_failed_logins'
         ]
         self.assertEqual(set(response.data.keys()), set(expected_keys))
 
@@ -1415,6 +1418,139 @@ class DashboardAPITests(TestCase):
                 'error': 'Invalid date format. Use YYYY-MM-DD format.',
             },
         )
+
+    # TDD: Tests for total_successful_logins and total_failed_logins
+    def test_user_stats_includes_successful_and_failed_logins(self):
+        """Test that user stats includes total_successful_logins and
+        total_failed_logins."""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('user:dashboard-stats')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('total_successful_logins', response.data)
+        self.assertIn('total_failed_logins', response.data)
+        self.assertIsInstance(response.data['total_successful_logins'], int)
+        self.assertIsInstance(response.data['total_failed_logins'], int)
+
+    def test_user_stats_successful_and_failed_counts_are_accurate(self):
+        """Test that successful and failed login counts match actual
+        LoginActivity records."""
+        # Clear existing activities
+        LoginActivity.objects.filter(user=self.user).delete()
+
+        # Create exactly 3 successful and 2 failed logins
+        for i in range(3):
+            LoginActivity.objects.create(
+                user=self.user,
+                ip_address=f'192.168.1.{i+1}',
+                user_agent=f'Success Browser {i+1}',
+                success=True
+            )
+        for i in range(2):
+            LoginActivity.objects.create(
+                user=self.user,
+                ip_address=f'192.168.2.{i+1}',
+                user_agent=f'Fail Browser {i+1}',
+                success=False
+            )
+
+        self.client.force_authenticate(user=self.user)
+        url = reverse('user:dashboard-stats')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['total_successful_logins'], 3)
+        self.assertEqual(response.data['total_failed_logins'], 2)
+        # total_logins should be sum of successful + failed
+        self.assertEqual(response.data['total_logins'], 5)
+
+    def test_user_stats_data_structure_includes_new_fields(self):
+        """Test that user stats response includes the new fields in data
+        structure."""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('user:dashboard-stats')
+        response = self.client.get(url)
+
+        expected_keys = [
+            'total_logins', 'last_login', 'weekly_data',
+            'monthly_data', 'login_trend',
+            'total_successful_logins', 'total_failed_logins'
+        ]
+        self.assertEqual(set(response.data.keys()), set(expected_keys))
+
+    def test_admin_dashboard_user_stats_matches_regular_user_stats(self):
+        """Integration test: admin dashboard filtered by user_id should show
+        same success/fail counts as that user's own stats."""
+        # Clear all activities first
+        LoginActivity.objects.all().delete()
+
+        # Create a new regular user
+        regular_user = User.objects.create_user(
+            username='regularstatsuser',
+            email='regularstats@example.com',
+            password='regularpass123'
+        )
+
+        # Create mixed login activities for this user
+        # 4 successful, 1 failed
+        for i in range(4):
+            LoginActivity.objects.create(
+                user=regular_user,
+                ip_address=f'10.0.0.{i+1}',
+                user_agent=f'Regular Browser {i+1}',
+                success=True
+            )
+        LoginActivity.objects.create(
+            user=regular_user,
+            ip_address='10.0.0.99',
+            user_agent='Fail Browser',
+            success=False
+        )
+
+        # Get regular user's own stats
+        self.client.force_authenticate(user=regular_user)
+        url = reverse('user:dashboard-stats')
+        user_response = self.client.get(url)
+
+        self.assertEqual(user_response.status_code, status.HTTP_200_OK)
+        user_success = user_response.data['total_successful_logins']
+        user_fail = user_response.data['total_failed_logins']
+        user_total = user_response.data['total_logins']
+
+        # Now login as admin and get dashboard for this specific user
+        self.client.force_authenticate(user=self.admin_user)
+        admin_url = reverse('user:admin-dashboard')
+        admin_response = self.client.get(
+            admin_url, {'user_ids[]': [regular_user.id]}
+        )
+
+        self.assertEqual(admin_response.status_code, status.HTTP_200_OK)
+        admin_success = admin_response.data['total_successful_logins']
+        admin_fail = admin_response.data['total_failed_logins']
+        admin_total = admin_response.data['total_logins']
+
+        # Verify all counts match between user stats and admin dashboard
+        self.assertEqual(
+            admin_success, user_success,
+            "Admin successful logins should match user's successful logins"
+        )
+        self.assertEqual(
+            admin_fail, user_fail,
+            "Admin failed logins should match user's failed logins"
+        )
+        self.assertEqual(
+            admin_total, user_total,
+            "Admin total logins should match user's total logins"
+        )
+
+        # Additional sanity checks (4 successful + 1 failed = 5 total)
+        self.assertEqual(user_success, 4)
+        self.assertEqual(user_fail, 1)
+        self.assertEqual(user_total, 5)
+        self.assertEqual(admin_success, 4)
+        self.assertEqual(admin_fail, 1)
+        self.assertEqual(admin_total, 5)
 
     def test_user_specific_stats_date_filtering_works(self):
         """Test user-specific stats endpoint date filtering."""  # noqa: E501

--- a/app/user/tests/test_login_activity_recording.py
+++ b/app/user/tests/test_login_activity_recording.py
@@ -150,8 +150,10 @@ class LoginActivityRecordingTests(TestCase):
         url = reverse('user:dashboard-stats')
         response = self.client.get(url)
 
-        # Should only count successful logins (5)
-        self.assertEqual(response.data['total_logins'], 5)
+        # Should count all login attempts (5 successful + 2 failed = 7)
+        self.assertEqual(response.data['total_logins'], 7)
+        self.assertEqual(response.data['total_successful_logins'], 5)
+        self.assertEqual(response.data['total_failed_logins'], 2)
 
     def test_user_stats_includes_login_trend_calculation(self):
         """Test that user stats includes login trend calculation."""

--- a/app/user/views_dashboard.py
+++ b/app/user/views_dashboard.py
@@ -105,7 +105,9 @@ class UserStatsView(generics.GenericAPIView):
                     "weekly_data": {
                         "2025-12-07": 5, "2025-12-08": 3, "2025-12-09": 7},
                     "monthly_data": {"2025-11": 15, "2025-12": 27},
-                    "login_trend": 80
+                    "login_trend": 80,
+                    "total_successful_logins": 42,
+                    "total_failed_logins": 3
                 },
                 response_only=True,
                 status_codes=["200"]
@@ -117,7 +119,9 @@ class UserStatsView(generics.GenericAPIView):
                     "last_login": "2025-12-10 14:30:25",
                     "weekly_data": {"2025-12-09": 5, "2025-12-10": 10},
                     "monthly_data": {"2025-12": 15},
-                    "login_trend": 25
+                    "login_trend": 25,
+                    "total_successful_logins": 15,
+                    "total_failed_logins": 1
                 },
                 response_only=True,
                 status_codes=["200"]


### PR DESCRIPTION
Adds total_successful_logins and total_failed_logins to /api/user/dashboard/stats/. Updates total_logins to count all login attempts (consistent with admin dashboard). Includes TDD tests and admin-user stats integration test.