### PR TITLE
fix: include full last day in date range filtering for all dashboard endpoints

### DIFF
--- a/app/user/serializers_dashboard.py
+++ b/app/user/serializers_dashboard.py
@@ -383,6 +383,10 @@ def get_login_trends_data(user, start_date=None, end_date=None):
     # Generate all dates in range for consistent data structure
     current_date = start_date.date()
     end_date_date = end_date.date()
+    # If end_date has a time component (not exactly midnight),
+    # include the full day by treating it as the next day
+    if end_date.time() != timezone.datetime.min.time():
+        end_date_date += timedelta(days=1)
 
     # Create date to data mapping for fast lookup
     data_map = {}
@@ -394,7 +398,7 @@ def get_login_trends_data(user, start_date=None, end_date=None):
         }
 
     # Build complete data arrays
-    while current_date <= end_date_date:
+    while current_date < end_date_date:
         date_str = current_date.strftime('%Y-%m-%d')
         dates.append(date_str)
 
@@ -656,6 +660,10 @@ def get_combined_login_trends_data(users, start_date=None, end_date=None):
     # Generate all dates in range for consistent data structure
     current_date = start_date.date()
     end_date_date = end_date.date()
+    # If end_date has a time component (not exactly midnight),
+    # include the full day by treating it as the next day
+    if end_date.time() != timezone.datetime.min.time():
+        end_date_date += timedelta(days=1)
 
     # Create date to data mapping for fast lookup
     data_map = {}
@@ -667,7 +675,7 @@ def get_combined_login_trends_data(users, start_date=None, end_date=None):
         }
 
     # Build complete data arrays
-    while current_date <= end_date_date:
+    while current_date < end_date_date:
         date_str = current_date.strftime('%Y-%m-%d')
         dates.append(date_str)
 

--- a/app/user/tests/test_dashboard_api.py
+++ b/app/user/tests/test_dashboard_api.py
@@ -1630,3 +1630,92 @@ class DashboardAPITests(TestCase):
                 'error': 'Invalid date format. Use YYYY-MM-DD format.',
             },
         )
+
+    # TDD: Tests for end-of-day inclusion bug
+    # (date filter should include full day)
+    def test_user_stats_includes_logins_on_last_day_of_range(self):
+        """Test that user stats includes logins occurring on the last day
+        of the date range, even if they are after midnight.
+
+        Regression test: the old code parsed end_date as
+        YYYY-MM-DD 00:00:00, which excluded any login after midnight
+        on the last day.
+        """
+        # Clear existing activities
+        LoginActivity.objects.filter(user=self.user).delete()
+
+        # Create a login at 3:00 PM today (after midnight)
+        today_3pm = timezone.now().replace(
+            hour=15, minute=0, second=0, microsecond=0
+        )
+        activity = LoginActivity.objects.create(
+            user=self.user,
+            ip_address='192.168.1.100',
+            user_agent='Test Browser',
+            success=True
+        )
+        activity.timestamp = today_3pm
+        activity.save()
+
+        self.client.force_authenticate(user=self.user)
+        url = reverse('user:dashboard-stats')
+
+        # Query with today as both start and end date
+        today_str = today_3pm.strftime('%Y-%m-%d')
+
+        response = self.client.get(url, {
+            'start_date': today_str,
+            'end_date': today_str,
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # The login at 3 PM today MUST be included
+        self.assertEqual(
+            response.data['total_logins'],
+            1,
+            "Login at 3:00 PM on last day should be included in range"
+        )
+
+    def test_admin_dashboard_includes_logins_on_last_day_of_range(self):
+        """Test that admin dashboard includes logins occurring on the
+        last day of the date range, even if they are after midnight.
+
+        Regression test: the old code parsed end_date as
+        YYYY-MM-DD 00:00:00, which excluded any login after midnight
+        on the last day.
+        """
+        # Clear existing activities
+        LoginActivity.objects.filter(user=self.user).delete()
+
+        # Create a login at 3:00 PM today (after midnight)
+        today_3pm = timezone.now().replace(
+            hour=15, minute=0, second=0, microsecond=0
+        )
+        activity = LoginActivity.objects.create(
+            user=self.user,
+            ip_address='192.168.1.100',
+            user_agent='Test Browser',
+            success=True
+        )
+        activity.timestamp = today_3pm
+        activity.save()
+
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('user:admin-dashboard')
+
+        # Query with today as both start and end date
+        today_str = today_3pm.strftime('%Y-%m-%d')
+
+        response = self.client.get(url, {
+            'user_ids[]': [self.user.id],
+            'start_date': today_str,
+            'end_date': today_str,
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # The login at 3 PM today MUST be included
+        self.assertEqual(
+            response.data['total_logins'],
+            1,
+            "Login at 3:00 PM on the last day should be included in date range"
+        )

--- a/app/user/views_dashboard.py
+++ b/app/user/views_dashboard.py
@@ -65,7 +65,7 @@ class DateFilteredAPIView(generics.GenericAPIView):
         return start_date, end_date
 
 
-class UserStatsView(generics.GenericAPIView):
+class UserStatsView(DateFilteredAPIView, generics.GenericAPIView):
     """API endpoint to get user statistics."""
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = UserStatsSerializer
@@ -134,25 +134,9 @@ class UserStatsView(generics.GenericAPIView):
     )
     def get(self, request):
         """Return comprehensive statistics for the authenticated user."""
-        start_date = request.query_params.get('start_date')
-        end_date = request.query_params.get('end_date')
-
-        # Convert string dates to datetime objects if provided
-        if start_date or end_date:
-            try:
-                if start_date:
-                    start_date = timezone.make_aware(
-                        datetime.strptime(start_date, '%Y-%m-%d'),
-                        timezone=timezone.utc)
-                if end_date:
-                    end_date = timezone.make_aware(
-                        datetime.strptime(end_date, '%Y-%m-%d'),
-                        timezone=timezone.utc)
-            except ValueError:
-                return Response(
-                    {'error': 'Invalid date format. Use YYYY-MM-DD format.'},
-                    status=status.HTTP_400_BAD_REQUEST
-                )
+        # Use base class method for consistent date parsing
+        # (includes +1 day to end_date for inclusive filtering)
+        start_date, end_date = self.get_date_filters(request)
 
         user_stats = get_user_stats(request.user, start_date, end_date)
         serializer = self.get_serializer(user_stats)
@@ -263,7 +247,7 @@ class LoginActivityView(DateFilteredAPIView, generics.ListAPIView):
         return queryset
 
 
-class AdminDashboardView(generics.GenericAPIView):
+class AdminDashboardView(DateFilteredAPIView, generics.GenericAPIView):
     """API endpoint to get admin dashboard data."""
     permission_classes = [IsStaffOrSuperUser]
     serializer_class = AdminDashboardSerializer
@@ -406,25 +390,16 @@ class AdminDashboardView(generics.GenericAPIView):
         me = request.query_params.get('me')
         user_ids = request.GET.getlist('user_ids[]')
         filter_type = request.query_params.get('filter')
-        start_date = request.query_params.get('start_date')
-        end_date = request.query_params.get('end_date')
 
-        # Parse and validate dates if provided
-        if start_date or end_date:
-            try:
-                if start_date:
-                    start_date = timezone.make_aware(
-                        datetime.strptime(start_date, '%Y-%m-%d'),
-                        timezone=timezone.utc)
-                if end_date:
-                    end_date = timezone.make_aware(
-                        datetime.strptime(end_date, '%Y-%m-%d'),
-                        timezone=timezone.utc)
-            except ValueError:
-                return Response(
-                    {'error': 'Invalid date format. Use YYYY-MM-DD format.'},
-                    status=status.HTTP_400_BAD_REQUEST
-                )
+        # Use base class method for consistent date parsing
+        # (includes +1 day to end_date for inclusive filtering)
+        try:
+            start_date, end_date = self.get_date_filters(request)
+        except ValidationError as e:
+            return Response(
+                e.detail,
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         # Validate parameters regardless of precedence
         # Validate role parameter if provided
@@ -491,7 +466,7 @@ class AdminDashboardView(generics.GenericAPIView):
 
 
 # Chart Data API Views
-class LoginTrendsView(generics.GenericAPIView):
+class LoginTrendsView(DateFilteredAPIView, generics.GenericAPIView):
     """API endpoint to get login trends data for line charts."""
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = ChartDataSerializer
@@ -619,24 +594,16 @@ class LoginTrendsView(generics.GenericAPIView):
     def get(self, request):
         """Return login trends data for the authenticated user or
         specified users."""
-        start_date = request.query_params.get('start_date')
-        end_date = request.query_params.get('end_date')
         user_ids = request.GET.getlist('user_ids[]')
         role = request.query_params.get('role')
 
-        # Convert string dates to datetime objects if provided
+        # Use base class method for consistent date parsing
+        # (includes +1 day to end_date for inclusive filtering)
         try:
-            if start_date:
-                start_date = timezone.make_aware(
-                    datetime.strptime(start_date, '%Y-%m-%d'),
-                    timezone=timezone.utc)
-            if end_date:
-                end_date = timezone.make_aware(
-                    datetime.strptime(end_date, '%Y-%m-%d'),
-                    timezone=timezone.utc)
-        except ValueError:
+            start_date, end_date = self.get_date_filters(request)
+        except ValidationError as e:
             return Response(
-                {'error': 'Invalid date format. Use YYYY-MM-DD format.'},
+                e.detail,
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -710,7 +677,7 @@ class LoginTrendsView(generics.GenericAPIView):
         })
 
 
-class LoginComparisonView(generics.GenericAPIView):
+class LoginComparisonView(DateFilteredAPIView, generics.GenericAPIView):
     """API endpoint to get login comparison data for bar charts."""
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = ChartDataSerializer
@@ -819,24 +786,16 @@ class LoginComparisonView(generics.GenericAPIView):
     def get(self, request):
         """Return login comparison data for the authenticated user or
         specified users."""
-        start_date = request.query_params.get('start_date')
-        end_date = request.query_params.get('end_date')
         user_ids = request.GET.getlist('user_ids[]')
         role = request.query_params.get('role')
 
-        # Convert string dates to datetime objects if provided
+        # Use base class method for consistent date parsing
+        # (includes +1 day to end_date for inclusive filtering)
         try:
-            if start_date:
-                start_date = timezone.make_aware(
-                    datetime.strptime(start_date, '%Y-%m-%d'),
-                    timezone=timezone.utc)
-            if end_date:
-                end_date = timezone.make_aware(
-                    datetime.strptime(end_date, '%Y-%m-%d'),
-                    timezone=timezone.utc)
-        except ValueError:
+            start_date, end_date = self.get_date_filters(request)
+        except ValidationError as e:
             return Response(
-                {'error': 'Invalid date format. Use YYYY-MM-DD format.'},
+                e.detail,
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -910,7 +869,7 @@ class LoginComparisonView(generics.GenericAPIView):
         })
 
 
-class LoginDistributionView(generics.GenericAPIView):
+class LoginDistributionView(DateFilteredAPIView, generics.GenericAPIView):
     """API endpoint to get login distribution data for pie charts."""
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = ChartDataSerializer
@@ -1042,24 +1001,16 @@ class LoginDistributionView(generics.GenericAPIView):
     def get(self, request):
         """Return login distribution data for the authenticated user or
         specified users."""
-        start_date = request.query_params.get('start_date')
-        end_date = request.query_params.get('end_date')
         user_ids = request.GET.getlist('user_ids[]')
         role = request.query_params.get('role')
 
-        # Convert string dates to datetime objects if provided
+        # Use base class method for consistent date parsing
+        # (includes +1 day to end_date for inclusive filtering)
         try:
-            if start_date:
-                start_date = timezone.make_aware(
-                    datetime.strptime(start_date, '%Y-%m-%d'),
-                    timezone=timezone.utc)
-            if end_date:
-                end_date = timezone.make_aware(
-                    datetime.strptime(end_date, '%Y-%m-%d'),
-                    timezone=timezone.utc)
-        except ValueError:
+            start_date, end_date = self.get_date_filters(request)
+        except ValidationError as e:
             return Response(
-                {'error': 'Invalid date format. Use YYYY-MM-DD format.'},
+                e.detail,
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -1133,7 +1084,7 @@ class LoginDistributionView(generics.GenericAPIView):
         })
 
 
-class AdminChartsView(generics.GenericAPIView):
+class AdminChartsView(DateFilteredAPIView, generics.GenericAPIView):
     """API endpoint to get admin-level chart data."""
     permission_classes = [IsStaffOrSuperUser]
     serializer_class = ChartDataSerializer
@@ -1211,22 +1162,13 @@ class AdminChartsView(generics.GenericAPIView):
     )
     def get(self, request):
         """Return comprehensive chart data for administrators."""
-        start_date = request.query_params.get('start_date')
-        end_date = request.query_params.get('end_date')
-
-        # Convert string dates to datetime objects if provided
+        # Use base class method for consistent date parsing
+        # (includes +1 day to end_date for inclusive filtering)
         try:
-            if start_date:
-                start_date = timezone.make_aware(
-                    datetime.strptime(start_date, '%Y-%m-%d'),
-                    timezone=timezone.utc)
-            if end_date:
-                end_date = timezone.make_aware(
-                    datetime.strptime(end_date, '%Y-%m-%d'),
-                    timezone=timezone.utc)
-        except ValueError:
+            start_date, end_date = self.get_date_filters(request)
+        except ValidationError as e:
             return Response(
-                {'error': 'Invalid date format. Use YYYY-MM-DD format.'},
+                e.detail,
                 status=status.HTTP_400_BAD_REQUEST
             )
 


### PR DESCRIPTION
- Add DateFilteredAPIView base class with inclusive end_date logic
- Fix UserStatsView, AdminDashboardView, and all chart views to use the centralized date parsing (end_date + 1 day for inclusive filtering)
- Update chart label generation to handle exclusive end_date correctly
- Add regression tests for end-of-day login inclusion bug

Fixes bug where logins after midnight on the last day of a date range were excluded from User Statistics, Admin Overview, and chart data.