### PR TITLE
feat: send verification email on admin 'Add User' and auto-verify superuser

### DIFF
--- a/app/core/admin.py
+++ b/app/core/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from .models import User
+from .email_service import send_verification_email, build_verification_url
 
 
 @admin.register(User)
@@ -48,6 +49,19 @@ class UserAdmin(BaseUserAdmin):
         'last_login',
     ]
     actions = ['verify_emails']
+
+    def save_model(self, request, obj, form, change):
+        """Override save_model to send verification email for new users."""
+        if not change:
+            # New user being created
+            super().save_model(request, obj, form, change)
+            obj.generate_verification_token()
+            verification_url = build_verification_url(
+                request, obj.verification_token, email=obj.email
+            )
+            send_verification_email(obj, verification_url)
+        else:
+            super().save_model(request, obj, form, change)
 
     @admin.display(description='Email Verified')
     def email_verified_status(self, obj):

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -27,6 +27,7 @@ class UserManager(BaseUserManager):
         user = self.create_user(username, email, password)
         user.is_staff = True
         user.is_superuser = True
+        user.email_verified = True
         user.save(using=self._db)
 
         return user

--- a/app/core/tests/test_admin.py
+++ b/app/core/tests/test_admin.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from django.test import TestCase, Client
 from django.contrib.auth import get_user_model
 from django.urls import reverse
@@ -110,7 +111,8 @@ class AdminSiteTests(TestCase):
         self.assertIn('password1', add_fields)
         self.assertNotIn('password', add_fields)
 
-    def test_create_user_via_admin_form(self):
+    @patch('core.admin.send_verification_email')
+    def test_create_user_via_admin_form(self, mock_send_email):
         """Test that a user can be created successfully via the admin form"""
         url = reverse('admin:core_user_add')
         data = {
@@ -127,6 +129,35 @@ class AdminSiteTests(TestCase):
             username='newadminuser'
         ).exists()
         self.assertTrue(user_exists)
+
+    @patch('core.admin.send_verification_email')
+    def test_create_user_via_admin_form_sends_verification_email(
+        self, mock_send_email
+    ):
+        """Test that creating a user via admin sends verification email"""
+        url = reverse('admin:core_user_add')
+        data = {
+            'username': 'verifyemailuser',
+            'email': 'verifyemail@example.com',
+            'password1': 'testpass123',
+            'password2': 'testpass123',
+        }
+        res = self.client.post(url, data, follow=True)
+        self.assertEqual(res.status_code, 200)
+
+        # Verify the user was created
+        user = get_user_model().objects.get(
+            username='verifyemailuser'
+        )
+        self.assertEqual(user.email, 'verifyemail@example.com')
+        self.assertFalse(user.email_verified)
+
+        # Verify that send_verification_email was called exactly once
+        self.assertEqual(mock_send_email.call_count, 1)
+
+        # Verify that the user has a verification token
+        self.assertIsNotNone(user.verification_token)
+        self.assertIsNotNone(user.verification_token_created_at)
 
     # Email Verification Admin Tests
     def test_email_verified_status_in_list_display(self):

--- a/app/core/tests/test_models.py
+++ b/app/core/tests/test_models.py
@@ -52,6 +52,16 @@ class ModelTests(TestCase):
         self.assertTrue(user.is_superuser)
         self.assertTrue(user.is_staff)
 
+    def test_create_superuser_email_verified(self):
+        """Test creating new superuser auto-verifies email"""
+        user = get_user_model().objects.create_superuser(
+            username='admin',
+            email='admin@example.com',
+            password='test123'
+        )
+
+        self.assertTrue(user.email_verified)
+
     def test_create_user_with_duplicate_username(self):
         """Test creating a user with a duplicate username raises an error"""
         get_user_model().objects.create_user(


### PR DESCRIPTION
- Override save_model() in UserAdmin to generate token and send verification email when a new user is created via admin panel
- Set email_verified=True in create_superuser() so CLI-created superusers are auto-verified (no email needed for admin users)
- Add TDD test: test_create_superuser_email_verified
- Add TDD test: test_create_user_via_admin_form_sends_verification_email
- Refactor existing admin test to mock send_verification_email