### PR TITLE
Add frontend service, route root requests to React frontend

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,6 +38,17 @@ services:
     networks:
       - tdd-network
 
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+    container_name: frontend-prod
+    ports:
+      - "3000:80"
+    networks:
+      - tdd-network
+    restart: unless-stopped
+
   nginx:
     image: nginx:alpine
     ports:
@@ -48,6 +59,7 @@ services:
       - app-static:/static
     depends_on:
       - app
+      - frontend
     networks:
       - tdd-network
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,9 +3,9 @@ server {
     server_name _;
     client_max_body_size 10M;
 
-    # Root path — proxy to Django
+    # Root path — proxy to React frontend
     location / {
-        proxy_pass http://app:8000;
+        proxy_pass http://frontend:80;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Why a single docker-compose file for backend + frontend?

We consolidated both services into one `docker-compose.prod.yml`  instead of running separate compose stacks.

**1. Automatic DNS resolution** — Docker Compose creates DNS entries for each service name within the same file. Nginx's `proxy_pass http://frontend:80` resolves correctly because `frontend` is a service name in the same compose file. Separate stacks would require hardcoding container names (`frontend-prod`) instead.

**2. Single deploy command** — `docker compose -f docker-compose.prod.yml up -d --build` starts everything (backend API, database, frontend, nginx) in one step.

**3. Startup ordering** — `depends_on: [app, frontend]` ensures both Django and React are ready before Nginx starts routing traffic.

**4. Changes are independent** — Modifying React source code only requires rebuilding the frontend container (`docker compose up -d --build frontend`). The backend repo only needs updating if the frontend's `docker-compose.prod.yml` adds/changes ports, volumes, or environment variables.

Backend routes (`/admin/`, `/api/`, `/static/`, `/media/`) remain untouched and still proxy to `http://app:8000` (Django). Only the root `/` and non-API paths are handled by the React frontend.