### PR TITLE
feat: add role-based access control to UserDetailView and restrict Django admin for staff

### DIFF
--- a/app/core/admin.py
+++ b/app/core/admin.py
@@ -74,3 +74,27 @@ class UserAdmin(BaseUserAdmin):
     def verify_emails(self, request, queryset):
         """Bulk action to mark selected users as email verified."""
         queryset.update(email_verified=True)
+
+    def has_module_permission(self, request):
+        """Allow staff and superusers to see the admin module."""
+        return request.user.is_active and (
+            request.user.is_superuser or request.user.is_staff
+        )
+
+    def has_view_permission(self, request, obj=None):
+        """Allow staff and superusers to view records."""
+        return request.user.is_active and (
+            request.user.is_superuser or request.user.is_staff
+        )
+
+    def has_change_permission(self, request, obj=None):
+        """Only superusers can edit records."""
+        return request.user.is_active and request.user.is_superuser
+
+    def has_add_permission(self, request):
+        """Only superusers can add records."""
+        return request.user.is_active and request.user.is_superuser
+
+    def has_delete_permission(self, request, obj=None):
+        """Only superusers can delete records."""
+        return request.user.is_active and request.user.is_superuser

--- a/app/core/tests/test_admin.py
+++ b/app/core/tests/test_admin.py
@@ -130,6 +130,94 @@ class AdminSiteTests(TestCase):
         ).exists()
         self.assertTrue(user_exists)
 
+    def test_staff_can_view_user_change_page(self):
+        """Test that staff can view the user change page (read-only)."""
+        staff_user = get_user_model().objects.create_user(
+            username='staffuser',
+            email='staff@example.com',
+            password='password123',
+            is_staff=True
+        )
+        self.client.force_login(staff_user)
+        url = reverse('admin:core_user_change', args=[self.user.id])
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        # Staff should see the form but fields should be readonly
+        self.assertContains(res, 'email')
+
+    def test_staff_can_view_user_list(self):
+        """Test that staff can view the user list in admin."""
+        staff_user = get_user_model().objects.create_user(
+            username='staffuser2',
+            email='staff2@example.com',
+            password='password123',
+            is_staff=True
+        )
+        self.client.force_login(staff_user)
+        url = reverse('admin:core_user_changelist')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, self.user.username)
+
+    def test_staff_cannot_add_user_via_admin(self):
+        """Test that staff cannot access the add user page."""
+        staff_user = get_user_model().objects.create_user(
+            username='staffuser3',
+            email='staff3@example.com',
+            password='password123',
+            is_staff=True
+        )
+        self.client.force_login(staff_user)
+        url = reverse('admin:core_user_add')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_staff_cannot_delete_user_via_admin(self):
+        """Test that staff cannot access the delete user page."""
+        staff_user = get_user_model().objects.create_user(
+            username='staffuser4',
+            email='staff4@example.com',
+            password='password123',
+            is_staff=True
+        )
+        self.client.force_login(staff_user)
+        url = reverse('admin:core_user_delete', args=[self.user.id])
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_staff_cannot_change_user_via_admin_post(self):
+        """Test that staff cannot submit changes to a user via admin."""
+        staff_user = get_user_model().objects.create_user(
+            username='staffuser5',
+            email='staff5@example.com',
+            password='password123',
+            is_staff=True
+        )
+        self.client.force_login(staff_user)
+        url = reverse('admin:core_user_change', args=[self.user.id])
+        data = {
+            'username': 'hacked_username',
+            'email': self.user.email,
+        }
+        res = self.client.post(url, data, follow=True)
+        # Should be forbidden
+        self.assertEqual(res.status_code, 403)
+        # Verify the username was NOT changed
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'testuser')
+
+    def test_superuser_can_add_user_via_admin(self):
+        """Test that superuser can access the add user page."""
+        url = reverse('admin:core_user_add')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+
+    def test_superuser_can_delete_user_via_admin(self):
+        """Test that superuser can access the delete user page."""
+        url = reverse('admin:core_user_delete', args=[self.user.id])
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+
     @patch('core.admin.send_verification_email')
     def test_create_user_via_admin_form_sends_verification_email(
         self, mock_send_email

--- a/app/user/permissions.py
+++ b/app/user/permissions.py
@@ -18,3 +18,47 @@ class IsStaffOrSuperUser(permissions.BasePermission):
     def has_permission(self, request, view):
         return request.user and (request.user.is_staff
                                  or request.user.is_superuser)
+
+
+class UserDetailPermission(permissions.BasePermission):
+    """
+    Custom permission for UserDetailView with role-based access control.
+
+    Permission matrix:
+    - Regular user: Can view and edit their own record only.
+    - Staff user: Can view any user's record (read-only), edit own record only.
+    - Superuser: Full access (view, edit, delete any record).
+    """
+
+    def has_permission(self, request, view):
+        """Authenticated users can access the endpoint (object-level
+        check handles further restrictions)."""
+        return request.user and request.user.is_authenticated
+
+    def has_object_permission(self, request, view, obj):
+        """Check object-level permissions based on user role."""
+        user = request.user
+
+        # Superuser has full access
+        if user.is_superuser:
+            return True
+
+        # DELETE is only allowed for superusers
+        if request.method == 'DELETE':
+            return False
+
+        # Staff can view any record (read-only) and edit their own
+        if user.is_staff:
+            if request.method in permissions.SAFE_METHODS:
+                return True  # Staff can view any record
+            # Staff can only edit their own record
+            return obj == user
+
+        # Regular user can only access their own record
+        if request.method in permissions.SAFE_METHODS:
+            return obj == user
+        # Regular user can edit their own record
+        if request.method in ('PUT', 'PATCH'):
+            return obj == user
+
+        return False

--- a/app/user/tests/test_user_api.py
+++ b/app/user/tests/test_user_api.py
@@ -945,8 +945,16 @@ class PrivateUserApiTests(TestCase):
         res = self.client.get(USERS_URL)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_retrieve_specific_user_detail_for_non_admin_fail(self):
-        """Test retrieving a specific user's details for non-admin fails."""
+    def test_retrieve_own_detail_for_regular_user_success(self):
+        """Test that a regular user can retrieve their own details."""
+        url = reverse('user:user-detail', args=[self.user.id])
+        res = self.client.get(url)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data['username'], self.user.username)
+
+    def test_retrieve_other_user_detail_for_regular_user_fail(self):
+        """Test retrieving another user's details for regular user fails."""
         user = User.objects.create_user(
             email='test2@example.com',
             password='Password123',
@@ -957,8 +965,18 @@ class PrivateUserApiTests(TestCase):
 
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_update_user_for_non_admin_fail(self):
-        """Test updating a user for non-admin fails."""
+    def test_update_own_detail_for_regular_user_success(self):
+        """Test that a regular user can update their own details."""
+        url = reverse('user:user-detail', args=[self.user.id])
+        payload = {'username': 'newname'}
+        res = self.client.patch(url, payload)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'newname')
+
+    def test_update_other_user_for_regular_user_fail(self):
+        """Test updating another user for regular user fails."""
         user = User.objects.create_user(
             email='test2@example.com',
             password='Password123',
@@ -1516,8 +1534,16 @@ class StaffUserApiTests(TestCase):
         res = self.client.get(USERS_URL)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
 
-    def test_retrieve_specific_user_detail_for_staff_fail(self):
-        """Test retrieving a specific user's details for staff fails."""
+    def test_retrieve_own_detail_for_staff_success(self):
+        """Test that staff can retrieve their own details."""
+        url = reverse('user:user-detail', args=[self.user.id])
+        res = self.client.get(url)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data['username'], self.user.username)
+
+    def test_retrieve_other_user_detail_for_staff_success(self):
+        """Test that staff can view other user's details (read-only)."""
         user = User.objects.create_user(
             email='test2@example.com',
             password='Password123',
@@ -1526,10 +1552,11 @@ class StaffUserApiTests(TestCase):
         url = reverse('user:user-detail', args=[user.id])
         res = self.client.get(url)
 
-        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data['username'], user.username)
 
-    def test_delete_user_for_staff_fail(self):
-        """Test deleting a user for staff fails."""
+    def test_delete_other_user_for_staff_fail(self):
+        """Test that staff cannot delete other users."""
         user = User.objects.create_user(
             email='test2@example.com',
             password='Password123',
@@ -1540,8 +1567,25 @@ class StaffUserApiTests(TestCase):
 
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_update_user_for_staff_fail(self):
-        """Test updating a user for staff fails."""
+    def test_delete_own_user_for_staff_fail(self):
+        """Test that staff cannot delete their own account."""
+        url = reverse('user:user-detail', args=[self.user.id])
+        res = self.client.delete(url)
+
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_own_profile_for_staff_success(self):
+        """Test that staff can update their own profile."""
+        url = reverse('user:user-detail', args=[self.user.id])
+        payload = {'username': 'updatedstaff'}
+        res = self.client.patch(url, payload)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'updatedstaff')
+
+    def test_update_other_user_for_staff_fail(self):
+        """Test that staff cannot update other users."""
         user = User.objects.create_user(
             email='test2@example.com',
             password='Password123',

--- a/app/user/views.py
+++ b/app/user/views.py
@@ -17,7 +17,7 @@ from .serializers import (
 )
 from rest_framework_simplejwt.views import TokenObtainPairView
 from core.models import User
-from .permissions import IsSuperUser, IsStaffOrSuperUser
+from .permissions import IsStaffOrSuperUser, UserDetailPermission
 from .pagination import UserPagination
 from .rsa_key_manager import load_public_key, get_public_key_path
 
@@ -207,7 +207,7 @@ class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
     """Retrieve, update or delete a user's details."""
     serializer_class = UserSerializer
     queryset = User.objects.all()
-    permission_classes = [IsSuperUser]
+    permission_classes = [UserDetailPermission]
 
     def get_serializer(self, *args, **kwargs):
         """


### PR DESCRIPTION
- New UserDetailPermission: regular users self-only, staff read-only for others + self-edit, superuser full access
- Django admin: staff can only view, superuser has full CRUD
- Fixes 403 error when staff user accesses api/user/users/<id>/