### PR TITLE
feat: add automatic daily cleanup of expired blacklisted JWT tokens

### DIFF
--- a/app/core/apps.py
+++ b/app/core/apps.py
@@ -4,3 +4,14 @@ from django.apps import AppConfig
 class CoreConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'core'
+
+    def ready(self):
+        """
+        Start the daily token cleanup scheduler when Django starts.
+
+        This runs the scheduler in a background daemon thread that
+        calls cleanup_blacklisted_tokens --days 1 every 24 hours.
+        """
+        # Import here to avoid AppRegistryNotReady errors
+        from core.token_cleanup_scheduler import start_scheduler
+        start_scheduler()

--- a/app/core/management/commands/cleanup_blacklisted_tokens.py
+++ b/app/core/management/commands/cleanup_blacklisted_tokens.py
@@ -1,0 +1,95 @@
+"""
+Management command to clean up expired outstanding tokens and their
+associated blacklisted token entries.
+
+This command removes:
+- OutstandingToken records that have expired (expires_at < now)
+- Associated BlacklistedToken records (via cascade delete)
+
+Run this periodically (e.g., daily via cron) to prevent the
+token_blacklist tables from growing indefinitely.
+"""
+import logging
+from datetime import timedelta
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from rest_framework_simplejwt.token_blacklist.models import (
+    OutstandingToken,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Clean up expired outstanding tokens and their blacklist entries."""
+
+    help = (
+        "Remove expired outstanding tokens and their associated "
+        "blacklisted tokens."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--days',
+            type=int,
+            default=None,
+            help=(
+                "Only delete tokens that expired more than this many "
+                "days ago. If not set, deletes all expired tokens."
+            ),
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            default=False,
+            help="Show what would be deleted without actually deleting.",
+        )
+
+    def handle(self, *args, **options):
+        """Execute the cleanup command."""
+        now = timezone.now()
+        days = options.get('days')
+        dry_run = options.get('dry_run')
+
+        # Determine the cutoff datetime
+        if days is not None:
+            cutoff = now - timedelta(days=days)
+        else:
+            cutoff = now
+
+        # Query expired outstanding tokens
+        expired_qs = OutstandingToken.objects.filter(
+            expires_at__lt=cutoff
+        )
+
+        expired_count = expired_qs.count()
+
+        if expired_count == 0:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    'No expired tokens found to clean up.'
+                )
+            )
+            return
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f'[DRY RUN] Would delete {expired_count} expired '
+                    f'outstanding token(s) and their associated '
+                    f'blacklisted token(s).'
+                )
+            )
+            return
+
+        # Delete expired outstanding tokens
+        # BlacklistedToken entries are cascade-deleted automatically
+        expired_qs.delete()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'Successfully deleted {expired_count} expired '
+                f'outstanding token(s) and their associated '
+                f'blacklisted token(s).'
+            )
+        )

--- a/app/core/tests/test_commands.py
+++ b/app/core/tests/test_commands.py
@@ -2,9 +2,16 @@
 Test custom Django management commands.
 """
 from unittest.mock import patch
+from datetime import timedelta
 from django.core.management import call_command
 from django.db.utils import OperationalError
-from django.test import SimpleTestCase
+from django.test import TestCase, SimpleTestCase
+from django.utils import timezone
+from rest_framework_simplejwt.token_blacklist.models import (
+    OutstandingToken,
+    BlacklistedToken,
+)
+from django.contrib.auth import get_user_model
 
 
 @patch('core.management.commands.wait_for_db.Command.check')
@@ -29,3 +36,87 @@ class CommandTests(SimpleTestCase):
 
         self.assertEqual(patched_check.call_count, 6)
         patched_check.assert_called_with(databases=['default'])
+
+
+class CleanupBlacklistedTokensCommandTests(TestCase):
+    """Test the cleanup_blacklisted_tokens management command."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = get_user_model().objects.create_user(
+            username='testuser',
+            email='test@example.com',
+            password='testpass123'
+        )
+        now = timezone.now()
+
+        # Create an expired outstanding token (expired 1 hour ago)
+        self.expired_outstanding = OutstandingToken.objects.create(
+            user=self.user,
+            jti='expired-jti-1',
+            token='expired-token-1',
+            created_at=now - timedelta(hours=2),
+            expires_at=now - timedelta(hours=1),
+        )
+        # Create a blacklisted token for the expired outstanding token
+        self.expired_blacklisted = BlacklistedToken.objects.create(
+            token=self.expired_outstanding,
+        )
+
+        # Create a non-expired outstanding token (expires in 1 hour)
+        self.valid_outstanding = OutstandingToken.objects.create(
+            user=self.user,
+            jti='valid-jti-1',
+            token='valid-token-1',
+            created_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        # Create a blacklisted token for the valid outstanding token
+        self.valid_blacklisted = BlacklistedToken.objects.create(
+            token=self.valid_outstanding,
+        )
+
+    def test_cleanup_removes_expired_tokens_and_blacklist(self):
+        """Test that expired tokens and their blacklist entries are removed."""
+        call_command('cleanup_blacklisted_tokens')
+
+        # Expired outstanding token should be deleted
+        self.assertFalse(
+            OutstandingToken.objects.filter(
+                jti='expired-jti-1'
+            ).exists()
+        )
+        # Associated blacklisted token should also be deleted (cascade)
+        self.assertFalse(
+            BlacklistedToken.objects.filter(
+                id=self.expired_blacklisted.id
+            ).exists()
+        )
+
+    def test_cleanup_preserves_valid_tokens_and_blacklist(self):
+        """Test that non-expired tokens and their blacklist are preserved."""
+        call_command('cleanup_blacklisted_tokens')
+
+        # Valid outstanding token should still exist
+        self.assertTrue(
+            OutstandingToken.objects.filter(
+                jti='valid-jti-1'
+            ).exists()
+        )
+        # Associated blacklisted token should still exist
+        self.assertTrue(
+            BlacklistedToken.objects.filter(
+                id=self.valid_blacklisted.id
+            ).exists()
+        )
+
+    def test_cleanup_only_removes_own_blacklisted(self):
+        """
+        Test that cleanup only removes blacklist entries associated
+        with expired tokens, not all blacklisted tokens.
+        """
+        call_command('cleanup_blacklisted_tokens')
+
+        # Only the expired token's blacklist entry should be gone
+        remaining_blacklisted = BlacklistedToken.objects.count()
+        self.assertEqual(remaining_blacklisted, 1)

--- a/app/core/tests/test_token_cleanup_scheduler.py
+++ b/app/core/tests/test_token_cleanup_scheduler.py
@@ -1,0 +1,78 @@
+"""
+Tests for the token cleanup scheduler.
+"""
+from unittest.mock import patch, MagicMock
+from django.test import SimpleTestCase
+from core.token_cleanup_scheduler import start_scheduler, _scheduler_started
+
+
+class TokenCleanupSchedulerTests(SimpleTestCase):
+    """Test the token cleanup scheduler."""
+
+    def setUp(self):
+        """Reset the scheduler started flag before each test."""
+        _scheduler_started.clear()
+
+    @patch('core.token_cleanup_scheduler.schedule')
+    @patch('core.token_cleanup_scheduler.threading')
+    def test_scheduler_schedules_daily_cleanup(
+        self, mock_threading, mock_schedule
+    ):
+        """Test that the cleanup command is scheduled every day."""
+        mock_thread = MagicMock()
+        mock_threading.Thread.return_value = mock_thread
+
+        start_scheduler()
+
+        # Verify schedule.every(1).day.do(run_cleanup) was called
+        mock_schedule.every.assert_called_once_with(1)
+        mock_schedule.every.return_value.day.do.assert_called_once()
+        mock_thread.start.assert_called_once()
+
+    @patch('core.token_cleanup_scheduler.schedule')
+    @patch('core.token_cleanup_scheduler.threading')
+    def test_run_cleanup_calls_command(
+        self, mock_threading, mock_schedule
+    ):
+        """Test that run_cleanup calls the management command."""
+        from core.token_cleanup_scheduler import run_cleanup
+        with patch(
+            'core.token_cleanup_scheduler.call_command'
+        ) as mock_call_command:
+            run_cleanup()
+            mock_call_command.assert_called_once_with(
+                'cleanup_blacklisted_tokens',
+                days=1,
+            )
+
+    @patch('core.token_cleanup_scheduler.schedule')
+    @patch('core.token_cleanup_scheduler.threading')
+    def test_run_cleanup_handles_errors_gracefully(
+        self, mock_threading, mock_schedule
+    ):
+        """Test that run_cleanup does not crash on errors."""
+        from core.token_cleanup_scheduler import run_cleanup
+        with patch(
+            'core.token_cleanup_scheduler.call_command'
+        ) as mock_call_command:
+            mock_call_command.side_effect = Exception('Test error')
+            # Should not raise
+            run_cleanup()
+
+    @patch('core.token_cleanup_scheduler.schedule')
+    @patch('core.token_cleanup_scheduler.threading')
+    def test_scheduler_only_runs_once(
+        self, mock_threading, mock_schedule
+    ):
+        """Test that calling start_scheduler twice only creates one thread."""
+        mock_thread = MagicMock()
+        mock_threading.Thread.return_value = mock_thread
+
+        start_scheduler()
+        start_scheduler()
+
+        # Thread should only be created and started once
+        mock_threading.Thread.assert_called_once()
+        mock_thread.start.assert_called_once()
+        # schedule.every should only be called once
+        mock_schedule.every.assert_called_once()

--- a/app/core/token_cleanup_scheduler.py
+++ b/app/core/token_cleanup_scheduler.py
@@ -1,0 +1,67 @@
+"""
+Scheduler for daily token cleanup.
+
+Uses the `schedule` library to run cleanup_blacklisted_tokens --days 1
+every 24 hours in a background daemon thread. This prevents the
+OutstandingToken and BlacklistedToken tables from growing indefinitely.
+
+The scheduler is started automatically when Django starts
+(via core/apps.py -> CoreConfig.ready()).
+"""
+import logging
+import threading
+import schedule
+import time
+from django.core.management import call_command
+
+logger = logging.getLogger(__name__)
+
+# Threading event to ensure the scheduler starts only once
+_scheduler_started = threading.Event()
+
+
+def run_cleanup():
+    """Execute the cleanup_blacklisted_tokens management command."""
+    logger.info('Running scheduled cleanup of expired tokens...')
+    try:
+        call_command('cleanup_blacklisted_tokens', days=1)
+    except Exception as e:
+        logger.error('Token cleanup failed: %s', e, exc_info=True)
+
+
+def _run_pending_loop():
+    """
+    Continuously run pending scheduled jobs.
+
+    This function runs indefinitely in a daemon thread.
+    """
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+def start_scheduler():
+    """
+    Start the daily token cleanup scheduler in a background thread.
+
+    This function is idempotent: calling it more than once will
+    not create additional threads or duplicate scheduled jobs.
+    Uses a daemon thread so it does not block Django from shutting down.
+    """
+    if _scheduler_started.is_set():
+        return
+
+    # Schedule the cleanup job to run every day
+    schedule.every(1).day.do(run_cleanup)
+
+    # Start the scheduler loop in a daemon thread
+    thread = threading.Thread(
+        target=_run_pending_loop,
+        daemon=True,
+    )
+    thread.start()
+
+    _scheduler_started.set()
+    logger.info(
+        'Daily token cleanup scheduler started (interval: 24 hours).'
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv>=1.0.0,<2.0  # Load environment variables from .env file
 django-cors-headers>=3.13.0,<3.14  # CORS support for Django
 cryptography>=48.0.0,<49.0  # RSA encryption for login credential security
 openpyxl>=3.1.0,<4.0        # Excel report generation
+schedule>=1.0.0,<2.0         # Scheduled job runner for daily token cleanup


### PR DESCRIPTION
- Add cleanup_blacklisted_tokens management command to delete expired OutstandingToken records (cascade-deletes associated BlacklistedToken) with --days and --dry-run flags for safety
- Add token_cleanup_scheduler that uses the schedule library to run the cleanup command every 24 hours in a background daemon thread
- Integrate scheduler into Django startup via CoreConfig.ready()
- Add schedule>=1.0.0,<2.0 to requirements.txt
- Add 4 scheduler tests + 3 cleanup command tests

The scheduler deletes tokens that expired more than 1 day ago, running once every 24 hours automatically.