### PR TITLE
feat(admin): implement admin permissions for LoginActivity and GameScore models

### DIFF
--- a/app/core/admin.py
+++ b/app/core/admin.py
@@ -160,14 +160,26 @@ class LoginActivityAdmin(admin.ModelAdmin):
     ordering = ['-timestamp']
     list_per_page = 25
 
+    def has_module_permission(self, request):
+        """Allow staff and superusers to see the Login Activity module."""
+        return request.user.is_active and (
+            request.user.is_superuser or request.user.is_staff
+        )
+
     def has_add_permission(self, request):
         """Prevent adding login activity records via admin."""
         return False
 
+    def has_view_permission(self, request, obj=None):
+        """Allow both superusers and staff to view login activity records."""
+        return request.user.is_active and (
+            request.user.is_superuser or request.user.is_staff
+        )
+
     def has_change_permission(self, request, obj=None):
-        """Allow viewing but prevent editing of login activity records."""
-        return True
+        """Prevent any editing of login activity records."""
+        return False
 
     def has_delete_permission(self, request, obj=None):
-        """Prevent deleting login activity records via admin."""
-        return False
+        """Only superusers can delete login activity records."""
+        return request.user.is_superuser

--- a/app/core/tests/test_admin.py
+++ b/app/core/tests/test_admin.py
@@ -675,17 +675,21 @@ class LoginActivityAdminTests(TestCase):
             ['-timestamp']
         )
 
-    def test_login_activity_detail_page_shows_all_fields(self):
-        """Test that login activity detail page shows all fields."""
+    def test_login_activity_change_page_loads_read_only(self):
+        """Test that change page loads in read-only mode for all users."""
         url = reverse(
             'admin:core_loginactivity_change',
             args=[self.login_activity.id]
         )
         res = self.client.get(url)
+        # Django returns 200 with read-only display when
+        # has_change_permission is False
         self.assertEqual(res.status_code, 200)
         self.assertContains(res, self.regular_user.username)
         self.assertContains(res, '192.168.1.1')
         self.assertContains(res, 'Mozilla/5.0')
+        # Ensure there's no submit button (read-only mode)
+        self.assertNotContains(res, 'name="_save"')
 
     def test_login_activity_add_permission_denied_for_all(self):
         """Test that no one can add login activity via admin."""
@@ -693,14 +697,37 @@ class LoginActivityAdminTests(TestCase):
         res = self.client.get(url)
         self.assertEqual(res.status_code, 403)
 
-    def test_login_activity_delete_permission_denied_for_superuser(self):
-        """Test that superuser cannot delete login activity via admin."""
+    def test_superuser_can_delete_login_activity(self):
+        """Test that superuser can delete login activity via admin."""
         url = reverse(
             'admin:core_loginactivity_delete',
             args=[self.login_activity.id]
         )
         res = self.client.get(url)
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, 200)
+
+    def test_login_activity_module_appears_in_admin_index(self):
+        """Test that Login Activity module appears in admin index
+        for superuser."""
+        url = reverse('admin:index')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, 'Login Activities')
+
+    def test_login_activity_module_appears_for_staff(self):
+        """Test that Login Activity module appears in admin index
+        for staff user."""
+        staff_user = get_user_model().objects.create_user(
+            username='staffuser0',
+            email='staff0@example.com',
+            password='password123',
+            is_staff=True
+        )
+        self.client.force_login(staff_user)
+        url = reverse('admin:index')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, 'Login Activities')
 
     def test_staff_can_view_login_activity_list(self):
         """Test that staff can view the login activity list."""

--- a/app/game/admin.py
+++ b/app/game/admin.py
@@ -11,5 +11,29 @@ class GameScoreAdmin(admin.ModelAdmin):
     list_display = ['user', 'score', 'created_at']
     list_filter = ['score', 'created_at']
     search_fields = ['user__username', 'user__email']
-    readonly_fields = ['created_at']
+    readonly_fields = ['user', 'score', 'created_at']
     ordering = ['-score']
+
+    def has_module_permission(self, request):
+        """Allow staff and superusers to see the Game Scores module."""
+        return request.user.is_active and (
+            request.user.is_superuser or request.user.is_staff
+        )
+
+    def has_view_permission(self, request, obj=None):
+        """Allow staff and superusers to view game scores."""
+        return request.user.is_active and (
+            request.user.is_superuser or request.user.is_staff
+        )
+
+    def has_add_permission(self, request):
+        """Prevent anyone from adding game scores via admin."""
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        """Prevent editing game scores via admin."""
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        """Only superusers can delete game scores."""
+        return request.user.is_superuser

--- a/app/game/tests/test_admin.py
+++ b/app/game/tests/test_admin.py
@@ -1,0 +1,134 @@
+"""
+Tests for the game app admin configuration.
+"""
+from django.test import TestCase, Client
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.contrib import admin
+from game.models import GameScore
+
+
+class GameScoreAdminTests(TestCase):
+    """Test cases for GameScore admin registration and permissions."""
+
+    def setUp(self):
+        self.client = Client()
+        self.superuser = get_user_model().objects.create_superuser(
+            username='superadmin',
+            email='super@example.com',
+            password='password123'
+        )
+        self.staff_user = get_user_model().objects.create_user(
+            username='staffuser',
+            email='staff@example.com',
+            password='password123',
+            is_staff=True
+        )
+        self.regular_user = get_user_model().objects.create_user(
+            username='regularuser',
+            email='regular@example.com',
+            password='password123'
+        )
+
+        # Create a game score
+        self.game_score = GameScore.objects.create(
+            user=self.regular_user,
+            score=85.5
+        )
+
+    def test_game_score_model_registered_in_admin(self):
+        """Test GameScore model is registered in admin."""
+        self.assertIn(
+            GameScore,
+            admin.site._registry,
+            'GameScore model should be registered in admin site'
+        )
+
+    def test_game_score_module_appears_in_admin_index(self):
+        """Test that Game Scores module appears in admin index."""
+        self.client.force_login(self.superuser)
+        url = reverse('admin:index')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, 'Game scores')
+
+    def test_game_score_module_appears_for_staff(self):
+        """Test that Game Scores module appears in admin index
+        for staff user."""
+        staff_user = get_user_model().objects.create_user(
+            username='staffuser0',
+            email='staff0@example.com',
+            password='password123',
+            is_staff=True
+        )
+        self.client.force_login(staff_user)
+        url = reverse('admin:index')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, 'Game scores')
+
+    def test_superuser_can_view_game_score_list(self):
+        """Test that superuser can view the game score list."""
+        self.client.force_login(self.superuser)
+        url = reverse('admin:game_gamescore_changelist')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, self.regular_user.username)
+        self.assertContains(res, '85.5')
+
+    def test_staff_can_view_game_score_list(self):
+        """Test that staff can view the game score list."""
+        self.client.force_login(self.staff_user)
+        url = reverse('admin:game_gamescore_changelist')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, self.regular_user.username)
+        self.assertContains(res, '85.5')
+
+    def test_superuser_can_delete_game_score(self):
+        """Test that superuser can delete game scores."""
+        self.client.force_login(self.superuser)
+        url = reverse(
+            'admin:game_gamescore_delete',
+            args=[self.game_score.id]
+        )
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 200)
+
+    def test_staff_cannot_delete_game_score(self):
+        """Test that staff cannot delete game scores."""
+        self.client.force_login(self.staff_user)
+        url = reverse(
+            'admin:game_gamescore_delete',
+            args=[self.game_score.id]
+        )
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_no_one_can_add_game_score(self):
+        """Test that no one can add game score via admin."""
+        self.client.force_login(self.superuser)
+        url = reverse('admin:game_gamescore_add')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_staff_cannot_add_game_score(self):
+        """Test that staff cannot add game score."""
+        self.client.force_login(self.staff_user)
+        url = reverse('admin:game_gamescore_add')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 403)
+
+    def test_change_page_read_only_for_superuser(self):
+        """Test that change page loads in read-only mode for superuser."""
+        self.client.force_login(self.superuser)
+        url = reverse(
+            'admin:game_gamescore_change',
+            args=[self.game_score.id]
+        )
+        res = self.client.get(url)
+        # Django returns 200 with read-only display when
+        # has_change_permission is False
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, self.regular_user.username)
+        self.assertContains(res, '85.5')


### PR DESCRIPTION
- Add has_module_permission and has_view_permission to LoginActivityAdmin and GameScoreAdmin to restrict access to staff/superusers

- Make LoginActivity and GameScore read-only in admin (has_change_permission → False)

- Restrict delete permission to superusers only for both models

- Prevent adding new records via admin for GameScore (has_add_permission → False)

- Add user to GameScoreAdmin's readonly_fields

- Update and expand tests to cover new permission behaviors:

  - Verify read-only change page (no submit button)
  - Verify superuser can delete login activity records
  - Verify module appears in admin index for both superuser and staff

- Add new test file app/game/tests/test_admin.py