### PR TITLE
perf: reduce workers to 3, add max-requests, use lighter healthcheck endpoint

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -54,4 +54,4 @@ USER django-user
 # Use entrypoint script to ensure proper directory setup
 ENTRYPOINT ["/docker-entrypoint.sh"]
 # Production CMD uses Gunicorn (overridden by docker-compose.prod.yml, but set as default here)
-CMD ["gunicorn", "app.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "4", "--preload", "--timeout", "60"]
+CMD ["gunicorn", "app.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "3", "--preload", "--max-requests", "1000", "--max-requests-jitter", "200", "--timeout", "60"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,7 +8,13 @@ services:
       sh -c "python manage.py wait_for_db &&
              python manage.py migrate &&
              python manage.py collectstatic --noinput &&
-             gunicorn app.wsgi:application --bind 0.0.0.0:8000 --workers 4 --preload --timeout 60"
+             gunicorn app.wsgi:application
+               --bind 0.0.0.0:8000
+               --workers 3
+               --preload
+               --max-requests 1000
+               --max-requests-jitter 200
+               --timeout 60"
     # ---------------------------------------------------------------
     # environment:                # Commented: .env.production handles DB config
     #   - DB_HOST=db              # Uncomment these if NOT using RDS (Docker MySQL)
@@ -22,11 +28,11 @@ services:
     # depends_on:                 # Using RDS instead of Docker MySQL
     #   - db
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/admin/"]
-      interval: 10s
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/user/public-key/"]
+      interval: 30s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 3
+      start_period: 60s
     volumes:
       - app-media:/app/media
       - app-static:/app/static


### PR DESCRIPTION
## Problem
hits high memory:
- 4 Gunicorn workers consuming unnecessary RAM
- No memory leak protection — workers accumulate ORM/memory over time
- Healthcheck hitting `/admin/` every 10s (heavy: loads admin + DB + auth)

## Changes

| Change | File | Effect |
|--------|------|--------|
| Workers 4 → 3 | `docker-compose.prod.yml` | Saves ~50 MiB RAM |
| Add `--max-requests 1000 --max-requests-jitter 200` | `docker-compose.prod.yml` | Prevents memory leaks — workers restart after 1K requests |
| Healthcheck `/admin/` → `/api/user/public-key/` | `docker-compose.prod.yml` | Lighter endpoint — no DB, no auth |
| Healthcheck interval 10s→30s, retries 5→3, start_period 30s→60s | `docker-compose.prod.yml` | Reduces healthcheck frequency 3× |

## Estimated Impact
- **RAM saved:** ~50 MiB + no memory leaks
- **Healthcheck overhead:** ~50ms → ~5ms per check
- **Worker restart:** Never → Every 1000 requests (prevents memory buildup)
